### PR TITLE
Bump digest to v0.11, release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.3
+## Unreleased
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.3
+
+### Changes
+
+* Bumped `digest` to v0.11, which replaces `generic-array` with `hybrid-array`. `digest::Output<H>` is now a `hybrid_array::Array` rather than a `GenericArray`.
+* Bumped `sha2` dev-dependency to v0.11
+* MSRV is now 1.85 (inherited from `digest` v0.11)
+* The `serde` feature now forwards to `hybrid-array/serde` instead of `generic-array/serde`
+* The `std` feature no longer forwards to `digest/std` (removed upstream in `digest` v0.11)
+
 ## v0.2
 
 ### Additions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,25 +4,25 @@ repository = "https://github.com/rozbb/ct-merkle"
 documentation = "https://docs.rs/ct-merkle"
 description = "An implementation of the append-only log described in the Certificate Transparency specification (RFC 6962)"
 readme = "README.md"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 keywords = ["crypto", "tls", "pki", "ct", "hash"]
 categories = ["no-std", "cryptography", "network-programming", "compression"]
 
 [dependencies]
-digest = "0.10"
-generic-array = "0.14"
+digest = "0.11"
+hybrid-array = { version = "0.4", optional = true }
 serde = { version = "1", optional = true, features = [ "derive" ] }
 subtle = { version = "2", default-features = false }
 
 [features]
 default = []
-std = [ "digest/std" ]
-serde = [ "dep:serde", "generic-array/serde" ]
+std = []
+serde = [ "dep:serde", "dep:hybrid-array", "hybrid-array/serde" ]
 
 [dev-dependencies]
 hex = "0.4"
 rand = { version = "0.9", features = [ "std_rng" ] }
 serde_json = "1"
-sha2 = "0.10"
+sha2 = "0.11"

--- a/src/consistency.rs
+++ b/src/consistency.rs
@@ -211,7 +211,7 @@ impl<H: Digest> RootHash<H> {
         let mut digests = proof
             .proof
             .chunks(H::OutputSize::USIZE)
-            .map(digest::Output::<H>::from_slice);
+            .map(|s| <&digest::Output<H>>::try_from(s).unwrap());
 
         // We compute both old and new tree hashes. This procedure will succeed iff the oldtree
         // hash matches old_root and the tree hash matches self

--- a/src/consistency.rs
+++ b/src/consistency.rs
@@ -35,7 +35,7 @@ impl<H: Digest> ConsistencyProof<H> {
     /// If when `bytes.len()` is not a multiple of `H::OutputSize::USIZE`, i.e., when `bytes` is not
     /// a concatenated sequence of hash digests.
     pub fn try_from_bytes(bytes: Vec<u8>) -> Result<Self, ConsistencyVerifError> {
-        if bytes.len() % H::OutputSize::USIZE != 0 {
+        if !bytes.len().is_multiple_of(H::OutputSize::USIZE) {
             Err(ConsistencyVerifError::MalformedProof)
         } else {
             Ok(ConsistencyProof {

--- a/src/inclusion.rs
+++ b/src/inclusion.rs
@@ -189,7 +189,7 @@ impl<H: Digest> RootHash<H> {
         // proof.len() is the correct length, which calculated as a multiple of the digest len
         for hash_slice in proof.chunks(H::OutputSize::USIZE) {
             // Hash the current node with its provided sibling
-            let sibling_hash = digest::Output::<H>::from_slice(hash_slice);
+            let sibling_hash = <&digest::Output<H>>::try_from(hash_slice).unwrap();
             if cur_idx.is_left(self.num_leaves) {
                 cur_hash = parent_hash::<H>(&cur_hash, sibling_hash);
             } else {

--- a/src/inclusion.rs
+++ b/src/inclusion.rs
@@ -33,7 +33,7 @@ impl<H: Digest> InclusionProof<H> {
     /// Panics when `bytes.len()` is not a multiple of `H::OutputSize::USIZE`, i.e., when `bytes` is
     /// not a concatenated sequence of hash digests.
     pub fn from_bytes(bytes: Vec<u8>) -> Self {
-        if bytes.len() % H::OutputSize::USIZE != 0 {
+        if !bytes.len().is_multiple_of(H::OutputSize::USIZE) {
             panic!("malformed inclusion proof");
         } else {
             InclusionProof {
@@ -61,7 +61,7 @@ impl<H: Digest> InclusionProof<H> {
     /// If when `bytes.len()` is not a multiple of `H::OutputSize::USIZE`, i.e., when `bytes`
     /// is not a concatenated sequence of hash digests.
     pub fn try_from_bytes(bytes: Vec<u8>) -> Result<Self, InclusionVerifError> {
-        if bytes.len() % H::OutputSize::USIZE != 0 {
+        if !bytes.len().is_multiple_of(H::OutputSize::USIZE) {
             return Err(InclusionVerifError::MalformedProof);
         }
 


### PR DESCRIPTION
digest 0.11 replaces generic-array with hybrid-array internally, so the direct generic-array dep is gone and the serde feature now forwards to hybrid-array/serde. sha2 dev-dep bumped to 0.11 to match. MSRV is now 1.85 (inherited from digest).